### PR TITLE
Add bulk import script

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,19 @@ DISCOGS_TOKEN=your_discogs_token
 python bot.py
 ```
 
+### 4. Bulk Import from Excel
+Use a two-line-per-record Excel sheet to quickly populate the database.
+Each record title goes on the first row, and the next row holds the price in GEL.
+
+Run the importer directly:
+
+```bash
+python bulk_import.py my_records.xlsx
+```
+
+You can also send the file to the bot with `/bulkimport` and it will add
+each item using the standard Discogs lookup flow.
+
 
 🗃 Folder Structure
 ```bash
@@ -58,6 +71,7 @@ record-store-bot/
 ├── sales.py             # /sell with cart and payment
 ├── reports.py           # /report generation and sending
 ├── inventory.py         # Inventory loader
+├── bulk_import.py       # Import simple Excel lists into the database
 ├── clime_db.xlsx        # Your Excel-based inventory
 ├── sales/               # Auto-generated sales reports
 ├── requirements.txt

--- a/add_record.py
+++ b/add_record.py
@@ -247,3 +247,26 @@ def start_add_flow():
         name="add_record",
         persistent=False
     )
+
+
+# === Automated Helpers ===
+def quick_add_from_discogs(query: str, price: float, condition: str = "nm", quantity: int = 1) -> str:
+    """Add a record to the DB using the first Discogs search result."""
+    results = list(d.search(query, type="release").page(1))
+    if not results:
+        raise ValueError(f"No Discogs results for {query}")
+
+    release = results[0]
+    row = [
+        str(release.title),
+        safe_join_list(release.genres),
+        safe_join_list(release.styles),
+        safe_get_labels(release),
+        safe_get_format(release),
+        str(condition),
+        float(price),
+        int(quantity),
+    ]
+
+    save_to_inventory(row)
+    return str(release.title)

--- a/bot.py
+++ b/bot.py
@@ -16,6 +16,7 @@ from auth import auth_manager, require_auth, create_auth_handlers, check_auth_mi
 from add_record import start_add_flow
 from sales import start_sell_flow
 from inventory import create_inventory_conversation
+from bulk_import import start_bulk_import_flow
 from db import init_db
 import inventory as inventory_utils
 import reports
@@ -207,6 +208,7 @@ def main():
     application.add_handler(start_add_flow())
     application.add_handler(start_sell_flow())
     application.add_handler(create_inventory_conversation())
+    application.add_handler(start_bulk_import_flow())
     
     # Add fallback handler for unauthorized access
     application.add_handler(MessageHandler(filters.ALL, unauthorized_handler))

--- a/bulk_import.py
+++ b/bulk_import.py
@@ -1,0 +1,112 @@
+"""Bulk import records from Excel using Discogs lookup."""
+
+import os
+import sys
+import tempfile
+from typing import List
+
+from openpyxl import load_workbook
+from telegram import Update
+from telegram.ext import (
+    CommandHandler,
+    MessageHandler,
+    ConversationHandler,
+    ContextTypes,
+    filters,
+)
+
+from auth import require_auth
+from add_record import quick_add_from_discogs
+from db import init_db
+
+
+WAITING_FOR_FILE = 0
+
+
+def bulk_import_from_excel(path: str) -> int:
+    """Read an Excel file and import records using Discogs lookup."""
+    wb = load_workbook(path)
+    ws = wb.active
+    rows: List[str] = [cell[0] for cell in ws.iter_rows(values_only=True)]
+
+    added = 0
+    for i in range(0, len(rows), 2):
+        title = rows[i]
+        if title is None:
+            continue
+        price = rows[i + 1] if i + 1 < len(rows) else None
+        if price is None:
+            continue
+        try:
+            price_val = float(price)
+        except (ValueError, TypeError):
+            continue
+
+        try:
+            quick_add_from_discogs(str(title), price_val)
+            added += 1
+        except Exception as e:
+            print(f"Failed to add '{title}': {e}")
+
+    return added
+
+
+@require_auth
+async def start_bulk_import(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    """Prompt user to send an Excel file for bulk import."""
+    await update.message.reply_text(
+        "📥 Send the Excel file (two rows per record: title then price)."
+    )
+    return WAITING_FOR_FILE
+
+
+async def handle_excel_file(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    """Receive the Excel file and process the import."""
+    document = update.message.document
+    if not document:
+        await update.message.reply_text("❌ Please send an Excel file.")
+        return WAITING_FOR_FILE
+
+    file = await document.get_file()
+    with tempfile.NamedTemporaryFile(delete=False, suffix=".xlsx") as tmp:
+        await file.download_to_drive(tmp.name)
+        temp_path = tmp.name
+
+    await update.message.reply_text("⏳ Importing records...")
+
+    count = bulk_import_from_excel(temp_path)
+    os.remove(temp_path)
+
+    await update.message.reply_text(f"✅ Imported {count} record(s) from file.")
+    return ConversationHandler.END
+
+
+async def cancel_bulk_import(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    """Cancel the bulk import conversation."""
+    await update.message.reply_text("✅ Bulk import cancelled.")
+    return ConversationHandler.END
+
+
+def start_bulk_import_flow() -> ConversationHandler:
+    """Return the ConversationHandler for the /bulkimport command."""
+    return ConversationHandler(
+        entry_points=[CommandHandler("bulkimport", start_bulk_import)],
+        states={
+            WAITING_FOR_FILE: [MessageHandler(filters.Document.ALL, handle_excel_file)]
+        },
+        fallbacks=[CommandHandler("cancel", cancel_bulk_import)],
+        name="bulk_import",
+        persistent=False,
+    )
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        print("Usage: python bulk_import.py <excel_file>")
+        sys.exit(1)
+
+    init_db()
+    total = bulk_import_from_excel(sys.argv[1])
+    print(f"Imported {total} record(s)")
+
+


### PR DESCRIPTION
## Summary
- add `/bulkimport` to upload Excel lists through the bot
- use Discogs lookup for each record via `quick_add_from_discogs`
- allow command line imports to remain
- document Excel import in README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687432dc315c832996c2480032cec998